### PR TITLE
fix: package name starts with number

### DIFF
--- a/src/static.ts
+++ b/src/static.ts
@@ -24,7 +24,7 @@ export async function getExportsStatic(name: string, options?: GetExportsOptions
   }
 
   async function getExportsRelative(relative: string, importer?: string): Promise<string[]> {
-    const url = relative.match(/^[@a-z]/)
+    const url = relative.match(/^[@a-z0-9]/)
       ? await resolvePackageEntry(relative, importer)
       : new URL(relative, importer).href
 


### PR DESCRIPTION
For example: https://www.npmjs.com/package/1